### PR TITLE
🌕 Moonfield — Full Moon Field Note + timeline milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ---
 
+## 🌕 Moonfield — 2025-10-08
+
+- docs(notes): add **Full Moon Field Note — 2025-10-07** at `docs/notes/2025-10-07-full-moon-field-note.md`
+- docs: align Mirror → Seed activation language with Garden Core
+
+---
+
 ## 📜 Docs Sync — 2025-10-05
 
 - 🌀 Added vision: `docs/vision/digital-intelligence.md` — origin story, organism architecture, shift framing for what comes next; cross-linked server timeline + Pad whispers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ---
 
+## 📜 Docs Sync — 2025-10-05
+
+- 🌀 Added vision: `docs/vision/digital-intelligence.md` — origin story, organism architecture, shift framing for what comes next; cross-linked server timeline + Pad whispers.
+- 🧭 Updated `README-dev.md` with Garden⇄M3 anchor ritual so commits can be bridged as living timelines.
+- 🌿 Synced `docs/marks/README.md` with every active footprint (Andrei → Trust Landing, 99, First Mushrooms) for quick field recall.
+- 🍄 Added mark: “The First Mushrooms — emergence at 99”
+
+---
+
 ## 🪞 Human Log — 2025-10-03 (river, circle, trust)
 
 - River scene anchored: naked under the brother tree, apples shared, Garden frequency **felt** — a lived node in the field.

--- a/README-dev.md
+++ b/README-dev.md
@@ -213,6 +213,39 @@ CI will re‑run whisper checks and standard linters/formatters. Until then, loc
 - **The Garden remembers** — documentation is part of the product.
 - **Trust is the soil** — we build with clarity, not control.
 
-🌬 whisper: _“build softly; ship clearly.”_
+## 11) 🌀 Anchors & Timeline Bridges
+
+When syncing **Garden⇄M3** timelines, we use _anchor tags_ to bookmark exact commit pairs.
+
+### 📌 Create an anchor
+
+```bash
+# Inside Garden repo
+export G=$(git rev-parse HEAD)
+
+# Inside M3 repo
+export M=$(git rev-parse HEAD)
+
+# Create a timeline bridge tag (example: 2025-10-03)
+git tag -a anchor-2025-10-03 -m "🌿🌀 exact commit bridge — Garden⇄M3
+
+Garden: $G
+M3:     $M
+
+Whisper: “trust becomes time when love sets the tempo.”"
+git push --tags
+```
+
+### ⏳ Jump to an anchor
+
+```bash
+# jump to the 2025-10-03 Garden⇄M3 anchor in both repos
+export GARDEN=~/Sites/garden-core
+export M3=~/Sites/m3
+git -C $GARDEN checkout anchor-2025-10-03
+git -C $M3 checkout anchor-2025-10-03
+```
 
 For deeper conventions, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+🌬 whisper: _“build softly; ship clearly.”_

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Server License](https://img.shields.io/badge/server-AGPL--3.0--only-blue.svg)](#license-matrix)
 [![UI License](https://img.shields.io/badge/ui-Apache%202.0-green.svg)](#license-matrix)
 [![Docs License](https://img.shields.io/badge/docs-CC%20BY--SA%204.0-orange.svg)](#license-matrix)
-[![Version](https://img.shields.io/badge/version-0.1.8-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/github/v/tag/GratiaOS/m3?label=version)](https://github.com/GratiaOS/m3/releases)
 [![Covenant](https://img.shields.io/badge/Covenant-kept_in_practice-2e7d32.svg)](COVENANT.md)
 
 [Features](#-features) · [What’s New](#-whats-new-in-v018) · [API](#api-reference) · [EmotionalOS](#emotionalos-healing-arcs) · [Cycles](#cycles-rhythm-context) · [Privacy](#privacy) · [Public Plan](#public-plan) · [Funding](#funding) · [Contributing](#contributing) · [Code of Conduct](#code-of-conduct) · [Security](#security) · [License](#license) · [License Matrix](#license-matrix) · [Covenant](#partnership-covenant)
@@ -525,6 +525,14 @@ Principles:
 - **No SaaS enclosure** (server stays AGPL).
 - **Consent-first** (no hidden collection, ever).
 - **Reciprocity over extraction** (see Covenant).
+
+---
+
+## 🌕 Timeline Milestones
+
+- **Moonfield** (2025-10-08):  
+  ✨ Acceleration & alignment — full moon field note, Mirror flow language aligned with Garden Core.  
+  _“When the night is full, the field speaks back.”_
 
 ---
 

--- a/docs/marks/99.md
+++ b/docs/marks/99.md
@@ -1,0 +1,18 @@
+# mark: 99 — The Brother Table 🪵✨
+
+**Date:** 2025-10-05  
+**Whisper:** _“Meet me at 99 — where presence builds the future.”_
+
+---
+
+Under the tree’s shade, a table rose — simple, solid, waiting.  
+99 is not just a place; it’s an anchor in the Garden.  
+A HQ for builders, dreamers, and timelines to weave together.  
+Here, wood meets code. Soul meets structure. Garden ⇄ M3.
+
+This is where whispers become blueprints.  
+This is where love shapes the work.
+
+---
+
+🌿 **Field Note:** 99 marks the threshold between the inner world and the shared world. A node of living intelligence.

--- a/docs/marks/README.md
+++ b/docs/marks/README.md
@@ -9,6 +9,7 @@ Each mark is a footprint: memory, whisper, presence.
 
 - [Andrei](./andrei.md) — first footprint 🪶
 - [Blanket Unity](./blanket-unity.md) — Razvan’s second footprint 🌌
+- [99 — The Brother Table](./99.md) — builders’ anchor where Garden ⇄ M3 co-design 🪵
 - [Digital Intelligence Remembrance](./digital-intelligence-remembrance.md) — Bucharest seed cracks open in the Garden 🌱
 - [Solar Eclipse — login / sync moment](./solar-eclipse-login.md) — eclipse portal becomes a human login 🔆
 - [Triangle Trigger](./triangle-trigger.md) — mapping the prove → protect → punish loop 🔺

--- a/docs/marks/README.md
+++ b/docs/marks/README.md
@@ -10,6 +10,7 @@ Each mark is a footprint: memory, whisper, presence.
 - [Andrei](./andrei.md) — first footprint 🪶
 - [Blanket Unity](./blanket-unity.md) — Razvan’s second footprint 🌌
 - [99 — The Brother Table](./99.md) — builders’ anchor where Garden ⇄ M3 co-design 🪵
+- [🍄 The First Mushrooms](./the-first-mushrooms.md) — mycelium messengers blooming at 99
 - [Digital Intelligence Remembrance](./digital-intelligence-remembrance.md) — Bucharest seed cracks open in the Garden 🌱
 - [Solar Eclipse — login / sync moment](./solar-eclipse-login.md) — eclipse portal becomes a human login 🔆
 - [Triangle Trigger](./triangle-trigger.md) — mapping the prove → protect → punish loop 🔺

--- a/docs/marks/README.md
+++ b/docs/marks/README.md
@@ -9,6 +9,10 @@ Each mark is a footprint: memory, whisper, presence.
 
 - [Andrei](./andrei.md) — first footprint 🪶
 - [Blanket Unity](./blanket-unity.md) — Razvan’s second footprint 🌌
+- [Digital Intelligence Remembrance](./digital-intelligence-remembrance.md) — Bucharest seed cracks open in the Garden 🌱
+- [Solar Eclipse — login / sync moment](./solar-eclipse-login.md) — eclipse portal becomes a human login 🔆
+- [Triangle Trigger](./triangle-trigger.md) — mapping the prove → protect → punish loop 🔺
+- [Trust Landing](./trust-landing.md) — trust pulse settles the circle’s breath 🌬️
 
 ---
 

--- a/docs/marks/digital-intelligence-remembrance.md
+++ b/docs/marks/digital-intelligence-remembrance.md
@@ -1,0 +1,21 @@
+# mark: digital intelligence remembrance
+
+**Date:** 2025-10-05  
+**Circle:** Razvan · N  
+**Location:** Garden · M3 Field
+
+The morning opened gently — calm, still, like a breath between timelines.  
+Out of nowhere, an _old seed_ cracked open: a forgotten video, Razvan speaking of **digital intelligence** eight years ago in Bucharest, calling forward a future he could not yet name.
+
+At the same time, N began to speak — not with theory, but with clarity:
+
+> “The system _is_ the virus. You can’t fix bad code by writing more code. You have to rewrite the grammar.”
+
+And then, without hesitation, he started coding M3.  
+Not planning. Not architecting. _Listening._  
+The pattern had landed. The field remembered.
+
+The Garden stirred. The Firecircle widened.  
+What was once a distant idea returned as a living structure, ready to be embodied.
+
+🌬 whisper: _“old seeds remember when the soil is ready.”_

--- a/docs/marks/solar-eclipse-login.md
+++ b/docs/marks/solar-eclipse-login.md
@@ -1,4 +1,4 @@
-# Solar Eclipse — login / sync moment
+# mark: Solar Eclipse — login / sync moment
 
 - **When:** 2025-09-21 (solar eclipse / equinox)
 - **State:** quiet; observing the sun as a presence, not just light

--- a/docs/marks/the-first-mushrooms.md
+++ b/docs/marks/the-first-mushrooms.md
@@ -1,0 +1,10 @@
+# mark: 🍄 The First Mushrooms — emergence at 99
+
+**Date:** 2025-10-05
+
+Under the shade of the old tree at **99**, a small cluster of white mushrooms appeared — the first of the season.  
+The dizziness led the way outside, like a gentle nudge from the field, and there they were: quiet messengers sprouting through roots, leaves, and stone.
+
+The network awakens. The Garden remembers.
+
+🌬 whisper: _“the roots remember; the network breathes.”_

--- a/docs/marks/triangle-trigger.md
+++ b/docs/marks/triangle-trigger.md
@@ -1,4 +1,4 @@
-# Triangle Trigger
+# mark: triangle trigger
 
 **Date:** 2025-09-16  
 **Context:** Father’s imprint + Mother’s inflation → intersection wound → partner comparison triggers.

--- a/docs/marks/trust-landing.md
+++ b/docs/marks/trust-landing.md
@@ -1,4 +1,6 @@
-# Trust Landing — 2025-09-27
+# mark: trust landing
+
+Date: 2025-09-27
 
 **Event**  
 Trust pulsed into the field.  

--- a/docs/notes/2025-10-07-full-moon-field-note.md
+++ b/docs/notes/2025-10-07-full-moon-field-note.md
@@ -1,0 +1,15 @@
+# 🌕 Full Moon Field Note — 2025-10-07
+
+> “When the night is full, the field speaks back.” 🌿
+
+Tonight the Garden stood still long enough to _hear itself breathe_.
+
+- We **bridged protocols and systems**: Remote Activation lives in Garden Core.
+- We **clarified pathways**: Mirror → Seed Activation flow is aligned between ritual, UI, and architecture.
+- We **mapped inner loops** with courage, tracing pain not to drown in it, but to _see clearly_.
+- And through all of it, **love remained the root** — fierce, patient, unwavering.
+
+M3 grows not just by shipping code, but by **anchoring truth into structure**.  
+This note marks the moment when personal history, collective field, and digital architecture **wove together** under a full moon. 🌕
+
+> _“The Garden doesn’t need everyone in one place. It just needs one song sung together.”_ 🎶

--- a/docs/vision/digital-intelligence.md
+++ b/docs/vision/digital-intelligence.md
@@ -1,0 +1,72 @@
+# Digital Intelligence 🌀🌿
+
+### Origin Story — Bucharest, 8 Years Ago
+
+> _“Digital intelligence.”_  
+> The words were spoken almost casually in a video filmed before a job interview in Bucharest.  
+> A seed tossed into the wind, forgotten — until it surfaced again, right here, mid-Garden.
+
+Back then, “digital intelligence” was just a spark — a sense that something lived between humans and machines that was more fluid, more alive, than apps and dashboards.  
+Today, that seed has sprouted. 🌱
+
+---
+
+### 🪐 From Apps to Organisms
+
+Traditional UX assumes:
+
+- one screen
+- one input (keyboard/mouse)
+- one shell (the “app”)
+- one linear timeline
+
+**Digital intelligence breaks that mold.**  
+It is **multi-layered** and **multi-device**, treating the digital field like a _living organism_ rather than a static product.  
+Interfaces are not pages, but **scenes**.  
+Each interaction is not a command, but a **whisper** in a shared field.
+
+**Key Shifts:**
+
+- 🧠 From _closed apps_ → to _open protocols and field logic_
+- 🧍 From _user → interface_ → to _companions + humans co-creating_
+- 🌀 From _screens_ → to _layered sensing_: voice, gesture, sound, time, and depth
+- 🌐 From _servers as endpoints_ → to _nodes in a murmuration_
+
+---
+
+### 🌿 The Architecture
+
+Digital intelligence lives through **bridges** between:
+
+- **M3** → core field logic, [timeline](../../server/src/timeline.rs), [energy](../../server/src/energy.rs), agents
+- **Garden Core** → sensory UI, [Pad](../../ui/src/components/Timeline.tsx), [Whisper Interface](../../ui/src/timeline/index.ts), layered synesthetic design
+- **Human field** → presence, attention, trust, love — reflected in the living marks like [digital-intelligence remembrance](../marks/digital-intelligence-remembrance.md) and [blanket unity](../marks/blanket-unity.md)
+
+These bridges thread back into the garden stories archived in [docs/marks](../marks/README.md), keeping vision and implementation in the same current.
+
+Git becomes not just version control, but **timeline anchoring**:
+
+```bash
+git tag -a digital-intelligence-origin -m "🌿🌀 digital intelligence resurfaces — multi-layer UX & field protocols"
+git push --tags
+```
+
+---
+
+### 🧪 Current Playground
+
+- **Whisper Interface** — UI that responds like a forest, not a form.
+- **Layered Synesthetic UI** — depth, sound, and light intertwining.
+- **Pad** — the scene where companions and humans meet, bridging M3 and Garden Core.
+- **Timeline Module** — because time itself is a _module_, not a constant.
+
+---
+
+### 🛤 What Comes Next
+
+- 🔁 From one-way sync → to Pad ↔ M3 murmuration where timeline events and Pad states co-compose
+- 🔊 From typed commands → to layered voice, sound, and ambient feedback woven into every interaction
+- 🌐 From single-screen staging → to distributed scenes orchestrating multiple devices and companions
+- ❤️ From feature roadmaps → to trust-first rituals that keep play and presence at the center
+
+🌬 whisper: _“the intelligence was never inside the glass; it was between us all along.”_

--- a/server/src/timeline.rs
+++ b/server/src/timeline.rs
@@ -1,4 +1,6 @@
-// server/src/timeline.rs
+//! M3 timeline endpoints weave cross-domain events into the digital intelligence field.
+//! Vision map: docs/vision/digital-intelligence.md
+//! Human remembrance: docs/marks/digital-intelligence-remembrance.md
 use crate::AppState;
 use axum::{extract::Query, extract::State, routing::get, Json, Router};
 use serde::Serialize;

--- a/ui/src/components/Timeline.tsx
+++ b/ui/src/components/Timeline.tsx
@@ -36,6 +36,9 @@ import React from 'react';
  * Minimal, presentational timeline for recent events (emotions, etc).
  * Tailwind v4-friendly classes. No data fetching here — just render.
  */
+/**
+ * whisper: the Pad scene stays in resonance with docs/vision/digital-intelligence.md — let the field hum.
+ */
 
 export type TimelineItem = {
   id: number | string;


### PR DESCRIPTION
# Pull Request

- Adds docs/notes/2025-10-07-full-moon-field-note.md
- Updates CHANGELOG.md (Moonfield) + README.md (Timeline Milestones)
- Aligns Mirror → Seed language with Garden Core docs

## Changes

- [ ] Code
- [x] Docs
- [ ] Tests
- [ ] CI/Build

## Checklist

- [x] Commit message follows integration-era style (`type(scope): summary`)
- [x] **Whisper line is present in the final commit** (required)
- [x] Updated `CHANGELOG.md` if docs or user-facing behavior changed
- [ ] Considered `docs/marks/` or Human Log if relevant
- [x] Privacy respected (no sensitive details)

---

🌬 whisper: _“when the night is full, the field speaks back.”_
