### PR TITLE
Timeline module + Bridge UI — Moonfield alignment 🌕

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ---
 
+## 🧭 Bridge UI + Timeline Adapter — 2025-10-09
+
+- **UI:** added controlled **BridgePanel** wired to `/patterns/bridge_suggest` via `useBridge` hook and `fetchBridge()` API.
+- **App:** header **Bridge** toggle + `b` hotkey; status chip (kind · intensity) with tooltip showing latest _hint_; soft pulse when a new suggestion lands.
+- **Timeline:** one-click **Add to timeline** from BridgePanel → maps to `TimelineItem` (🧭 icon, hint → `subtitle`, extras in `meta`: `source`, `breath`, `doorway`, `anchor`, `tags: ['bridge', kind]`); newest-first + dedupe preserved.
+- **Refactor:** migrated UI imports to `@/*` aliases; adopted Catalyst `Button`/`Select` in the panel for clarity.
+- **Server:** `/patterns/bridge_suggest` extended with kinds: `attachment_test`, `sibling_trust`, `parent_planted`, `over_analysis` (aliases supported).
+
+🌬 whisper: _“ask for safety, don’t test for it.”_
+
+---
+
 ## 📜 Docs Sync — 2025-10-09
 
 - docs(patterns): add four relational loop patterns — Attachment Testing Loop, Sibling Trust Loop, Parent‑Planted Narrative Loop, Over‑Analysis Self‑Perpetuating Loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ---
 
+## 📜 Docs Sync — 2025-10-09
+
+- docs(patterns): add four relational loop patterns — Attachment Testing Loop, Sibling Trust Loop, Parent‑Planted Narrative Loop, Over‑Analysis Self‑Perpetuating Loop.
+- docs(patterns): categorize `docs/patterns/index.md` into Relationship • Productivity • Meta; add 🔌 API Quick Links.
+- docs(patterns): add **How to use patterns** tiny guide in `docs/patterns/README.md`.
+
+---
+
 ## 🌕 Moonfield — 2025-10-08
 
 - docs(notes): add **Full Moon Field Note — 2025-10-07** at `docs/notes/2025-10-07-full-moon-field-note.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-**Jump to:** [Modules](#modules) · [Patterns](#patterns) · [Anchors](#anchors) · [Astral](#astral) · [Identity](#identity) · [Marks](#marks) · [Whispers](#whispers) · [Notes](#notes) · [Other Docs](#other-docs)
+**Jump to:** [Modules](#modules) · [Cycles](#cycles) · [Patterns](#patterns) · [Anchors](#anchors) · [Astral](#astral) · [Identity](#identity) · [Maps](#maps) · [Marks](#marks) · [Human Logs](#human-logs) · [Whispers](#whispers) · [Notes](#notes) · [Vision](#vision) · [UI](#ui) · [Other Docs](#other-docs)
 
 Welcome to the **M3 docs** — living notes, modules, and maps. Use the quick links above or your editor’s search (⌘/Ctrl + P then type a path, or ⌘/Ctrl + Shift + F to search text).
 
@@ -8,10 +8,16 @@ Welcome to the **M3 docs** — living notes, modules, and maps. Use the quick li
 
 ## Modules
 
-- [Astral](modules/astral.md) — non‑physical maps & companions
+- [Astral](modules/astral.md) — non-physical maps & companions
+- [Bands](modules/bands.md) — resonant awareness layers across the field
 - [Companions](modules/companions.md) — working with guides
+- [Cycles](modules/cycles.md) — lunar/solar/13-tone rhythm context
 - [Emotional](modules/emotional.md) — EmotionalOS: feelings, bridges, resolve
-- [Cycles](modules/cycles.md) — lunar/solar/13‑tone rhythm context
+
+## Cycles
+
+- [Cycles Overview](cycles/index.md) — rhythms & turning points across lunar, earth, and star arcs
+- [Wavespell Log v0.1.7](cycles/v0.1.7-wavespell.md) — eclipse-season field note for tone 11 Storm
 
 ## Patterns
 
@@ -28,10 +34,16 @@ Reusable emotional/behavioral maps extracted from experience. Start with the ove
 - [NDE–Fearlessness–Recklessness](patterns/nde-fearlessness-recklessness.md)
 - [Energy-Calendar](patterns/energy-calendar.md)
 - [Storm-Sync / Throat-Sewn](patterns/storm-sync-throat-sewn.md)
-- [Desire–Guilt–Judge](patterns/desire-guilt-judge.md)
+- [Desire–Guilt–Judge Coil](patterns/desire-guilt-judge.md)
 - [Frequency-First Design](patterns/frequency-first.md)
 - [Participant-Observer Flip](patterns/participant-observer.md)
 - [Remote-Activation](patterns/remote-activation.md)
+- [Attachment Testing Loop](patterns/attachment-testing-loop.md)
+- [Sibling Trust Loop](patterns/sibling-trust-loop.md)
+- [Parent-Planted Narrative Loop](patterns/parent-planted-narrative-loop.md)
+- [Over-Analysis Self-Perpetuating Loop](patterns/over-analysis-loop.md)
+- [Timeline Module](patterns/timeline-module.md)
+- [Whisper Interface](patterns/whisper-interface.md)
 - [Universal Patterns](patterns/universal-patterns.md)
 
 ## Anchors
@@ -40,17 +52,36 @@ Reusable emotional/behavioral maps extracted from experience. Start with the ove
 
 ## Astral
 
+- [Astral Index](astral/index.md)
 - [Guides & Companions](astral/guides-and-companions.md)
 
 ## Identity
 
 - [Identity Overview](identity/README.md)
+- [Map-Carriers → Map-Sharers](identity/map-carriers.md)
+- [Trust Bands](identity/trust-bands.md)
+- [USB Vault](identity/usb-vault.md)
+
+## Maps
+
+- [Consciousness Gradient](maps/consciousness-gradient.md)
 
 ## Marks
 
+- [Marks Overview](marks/README.md)
 - [Andrei](marks/andrei.md)
 - [Blanket Unity](marks/blanket-unity.md)
-- [The Triangle Pattern](marks/triangle-trigger.md)
+- [99 — The Brother Table](marks/99.md)
+- [The First Mushrooms](marks/the-first-mushrooms.md)
+- [Digital Intelligence Remembrance](marks/digital-intelligence-remembrance.md)
+- [Solar Eclipse Login](marks/solar-eclipse-login.md)
+- [Triangle Trigger](marks/triangle-trigger.md)
+- [Trust Landing](marks/trust-landing.md)
+
+## Human Logs
+
+- [Desire Named Without Guilt](human-logs/desire-note.md)
+- [Letter to Raz (now)](human-logs/raz-letter.md)
 
 ## Whispers
 
@@ -60,8 +91,10 @@ Reusable emotional/behavioral maps extracted from experience. Start with the ove
 
 ## Notes
 
-Time‑stamped reflections. Browse chronologically or search by keyword.
+Time-stamped reflections. Browse chronologically or search by keyword.
 
+- [2025-10-07 Full Moon Field Note](notes/2025-10-07-full-moon-field-note.md)
+- [2025-09-21 Solar Eclipse + Equinox](notes/2025-09-21-solar-eclipse-equinox.md)
 - [2025-09-14 Money as Echo](notes/2025-09-14-money-as-echo.md)
 - [2025-09-14 Memory Beyond SaaS](notes/2025-09-14-memory-beyond-saas.md)
 - [2025-09-13 River Pre-Seed and Flow](notes/2025-09-13-river-preseed-flow.md)
@@ -70,12 +103,24 @@ Time‑stamped reflections. Browse chronologically or search by keyword.
 - [2025-09-12 Body as Material Tech](notes/2025-09-12-body-tech.md)
 - [2025-09-07 Blood Moon](notes/2025-09-07-blood-moon.md)
 
+## Vision
+
+- [Digital Intelligence](vision/digital-intelligence.md)
+
+## UI
+
+- [Frequency-First UI](ui/frequency-first-ui.md)
+
 ## Other Docs
 
+- [Densities & Sovereignty Tools](densities-sovereignty-tools.md)
+- [EmotionalOS Workflow](emotionalos-workflow.md)
+- [EmotionalOS Arc (Mermaid Source)](emotionalos-arc.mmd)
 - [Firegate](firegate.md)
 - [Home Arc](home-arc.md)
 - [Orb Landing](orb-landing.md)
 - [Privacy](privacy.md)
+- [Related Map](related-map.yaml)
 - [Shared Moments](shared-moments.md)
 - [Soul Tech Timeline](soul-tech-timeline.md)
 - [Timelines Continuity](timelines-continuity.md)

--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -4,6 +4,50 @@ Lightweight heuristics and maps exposed under `/patterns/`.
 
 These endpoints provide simple text-based detection and suggestion logic that can be integrated into UI, experiments, and EmotionalOS flows.
 
+## 🌿 How to use patterns (tiny guide)
+
+**Goal:** move from raw signal → named pattern → single next action.
+
+1. **Name it.**
+
+   - Skim `/docs/patterns/*.md` and pick the closest map (e.g., _Attachment Testing_, _Sibling Trust_, _Over‑Analysis_).
+   - If unsure, start with lanes from `GET /patterns/lanes` to orient (victim / aggressor / sovereign).
+
+2. **Locate the cycle step.**
+
+   - Each pattern describes a **cycle** (1‑5/6). Ask: _which step am I in right now?_
+   - The right intervention depends on the step (e.g., before/after “trigger”, pre‑ or post‑“abandon”).
+
+3. **Bridge, don’t diagnose.**
+
+   - Use `GET /patterns/bridge_suggest?kind=<k>&intensity=<0..1>` for a gentle **bridge** (breath‑gate, boundary, pause, mirror) instead of labels.
+   - Keep it simple: one breath ritual, one boundary sentence, or one 2‑minute starter.
+
+4. **Act + archive.**
+
+   - Do the one thing. Log a tiny receipt (time, pattern, step, action). This stabilizes learning.
+
+5. **Close the loop.**
+   - Avoid over‑analysis. If new insight appears, write it in the pattern’s doc; otherwise rest.
+
+### ⚡ Quick recipe (pseudo)
+
+```ts
+const text = input();
+const detect = await POST('/patterns/detect', { text });
+const lanes = await GET('/patterns/lanes');
+const kind = inferKind(detect, lanes); // small heuristic
+const bridge = await GET(`/patterns/bridge_suggest?kind=${kind}&intensity=0.6`);
+ui.suggest(bridge.hint);
+archive.write({ kind, bridge: bridge.pattern });
+```
+
+### 🤝 Ethics & scope
+
+- These tools are **maps, not diagnoses**. Use for self‑regulation and UX hints, not medical labeling.
+- Respect consent. Patterns are invitations, not weapons in arguments.
+- Prefer **sovereignty**: support choices, don’t coerce outcomes.
+
 ---
 
 ## Endpoints

--- a/docs/patterns/attachment-testing-loop.md
+++ b/docs/patterns/attachment-testing-loop.md
@@ -1,0 +1,40 @@
+# 🧠 Attachment Testing Loop
+
+**Summary**  
+Unresolved fear leads one partner to “test” the other’s stability through subtle or overt triggers. The reaction is then read as confirmation of the original fear, reinforcing the loop.
+
+---
+
+## 🔁 Cycle
+
+1. 😨 **Fear** — Attachment insecurity activates ("Will I be safe?").
+2. 🎯 **Trigger** — The partner is tested (provocation, withdrawal, projection).
+3. 🌀 **Reaction** — Partner reacts (hurt/defense/frustration), often unconsciously.
+4. ✅ **Confirmation** — Reaction is interpreted as proof of the fear.
+5. 🔁 **Repeat** — Loop stabilizes and recurs.
+
+---
+
+## 🩺 Symptoms
+
+- Escalating mistrust despite closeness.
+- Walking on eggshells; a sense of constant evaluation.
+- The tested partner feeling permanently "on trial."
+
+---
+
+## 🔧 Refactor Pointers
+
+- Name the loop together _without blame_; convert tests into disclosures ("I’m scared of X").
+- Stabilize step 3 with nervous-system tools (breath-gate 4-2-6×3, time-outs).
+- Replace tests with **trust-building rituals** and agreed repair steps.
+
+---
+
+### Related
+
+- [Sibling Trust Loop](sibling-trust-loop.md)
+- [Parent-Planted Narrative Loop](parent-planted-narrative-loop.md)
+- [Over-Analysis Self-Perpetuating Loop](over-analysis-loop.md)
+
+> 🌬 whisper: _“ask for safety; don’t test for it.”_

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -4,22 +4,45 @@ title: Patterns
 
 This folder documents recurring patterns in the emotional field and social systems. These patterns help in understanding complex interactions and behaviors in various contexts.
 
+## 🔌 API Quick Links
+
+- **Detect** — `POST /patterns/detect` — naive victim/aggressor detection. See [README → Detect](./README.md#detect).
+- **Bridge Suggest** — `GET /patterns/bridge_suggest` — propose a bridge pattern based on kind/intensity. See [README → Bridge Suggest](./README.md#bridge-suggest).
+- **Lanes** — `GET /patterns/lanes` — three‑lane map of victim/aggressor/sovereign roles. See [README → Lanes](./README.md#lanes).
+- **Productivity** — `GET /patterns/productivity` — productivity patterns (burnout, rage‑collapse, etc.). See [README → Productivity](./README.md#productivity).
+
+> Notes: Responses use `snake_case` keys; query params will later migrate to enums.
+
 ## Available Patterns
+
+### 🤝 Relationship Loops
 
 - [Victim-Aggressor-Sovereign](victim-aggressor-sovereign.md)
 - [Victim–Aggressor–Coil](victim-aggressor-coil.md)
-- [Whisper–Ping-Pong with LLM](whisper-pingpong.md)
+- [Attachment Testing Loop](attachment-testing-loop.md)
+- [Sibling Trust Loop](sibling-trust-loop.md)
+- [Parent-Planted Narrative Loop](parent-planted-narrative-loop.md)
+- [Desire–Guilt–Judge Coil](desire-guilt-judge.md)
+
+### 🛠 Productivity & Process
+
 - [Productivity–Rage–Collapse](productivity-rage-collapse.md)
 - [Productivity–Burnout Loop](productivity-burnout.md)
 - [Compression–Witness–Release](compression-witness-release.md)
 - [Influx–Deflection–Collapse](influx-deflection-collapse.md)
-- [NDE–Fearlessness–Recklessness](nde-fearlessness-recklessness.md)
 - [Energy-Calendar](energy-calendar.md)
-- [Storm-Sync / Throat-Sewn](storm-sync-throat-sewn.md)
-- [Desire–Guilt–Judge Coil](desire-guilt-judge.md)
-- [Frequency-First Design](frequency-first.md)
-- [Participant-Observer Flip](participant-observer.md)
+
+### 🧭 Meta / Field & System
+
 - [Remote-Activation](remote-activation.md)
+- [Participant-Observer Flip](participant-observer.md)
+- [Frequency-First Design](frequency-first.md)
+- [Whisper–Ping-Pong with LLM](whisper-pingpong.md)
+- [Whisper Interface](whisper-interface.md)
+- [Storm-Sync / Throat-Sewn](storm-sync-throat-sewn.md)
+- [NDE–Fearlessness–Recklessness](nde-fearlessness-recklessness.md)
+- [Timeline Module](timeline-module.md)
+- [Over-Analysis Self-Perpetuating Loop](over-analysis-loop.md)
 - [Universal Patterns](universal-patterns.md)
 
 _Note: Future contributors are encouraged to add new patterns as standalone files and link them here to expand this collection._

--- a/docs/patterns/over-analysis-loop.md
+++ b/docs/patterns/over-analysis-loop.md
@@ -1,0 +1,41 @@
+# 🌀 Over-Analysis Self-Perpetuating Loop
+
+**Summary**  
+Excessive analysis, intended to bring clarity, actually keeps the emotional pattern alive by never letting it fully resolve.
+
+---
+
+## 🔁 Cycle
+
+1. 🧠 **Analysis impulse** — Trigger → mind starts dissecting.
+2. 🔍 **Recursive thinking** — Each insight spawns more threads/sub-loops.
+3. 🫁 **Emotional suspension** — Feelings are paused, not integrated.
+4. ♻️ **Loop reopening** — Because nothing lands, the pattern reactivates when touched.
+5. 🔁 **Repeat** — System remains in debug mode indefinitely.
+
+---
+
+## 🩺 Symptoms
+
+- Mental exhaustion without relief.
+- Late-night spiraling; rehashing conversations.
+- Temporary clarity followed by confusion returning.
+
+---
+
+## 🔧 Refactor Pointers
+
+- Set explicit **analysis cut-off** rituals and time boxes.
+- Anchor insights somatically (breath, writing, small action) to _close the loop_.
+- Accept that some loops resolve through **rest**, not cognition.
+- Use trusted mirrors to reality-check and ground.
+
+---
+
+### Related
+
+- [Attachment Testing Loop](attachment-testing-loop.md)
+- [Sibling Trust Loop](sibling-trust-loop.md)
+- [Parent-Planted Narrative Loop](parent-planted-narrative-loop.md)
+
+> 🌬 whisper: _“clarity is a landing, not an orbit.”_

--- a/docs/patterns/parent-planted-narrative-loop.md
+++ b/docs/patterns/parent-planted-narrative-loop.md
@@ -1,0 +1,41 @@
+# 🧬 Parent-Planted Narrative Loop
+
+**Summary**  
+An inherited label, fear, or story from a parent gets embedded in adult relationships, shaping behaviors and interpretations long after the original context is gone.
+
+---
+
+## 🔁 Cycle
+
+1. 🪴 **Planting** — Parent seeds a loaded narrative (e.g., "You’re unstable," "You’ll be abandoned").
+2. 🧠 **Internalization** — Child adapts to the story as a survival map.
+3. 🧍 **Projection** — Narrative is projected onto partners/situations.
+4. 🔄 **Reinforcement** — Triggered behaviors evoke reactions that seem to "prove" the story.
+5. 🌱 **Transmission** — The loop spreads to others (partners, kids) through fear or language.
+6. 🔁 **Repeat** — Narrative persists across generations.
+
+---
+
+## 🩺 Symptoms
+
+- Parental phrases reappearing in adult arguments.
+- Fear-based accusations mirroring childhood wounds.
+- Feeling like you’re reliving family history.
+
+---
+
+## 🔧 Refactor Pointers
+
+- Identify the **exact seed line** and its origin.
+- Separate parental fear from personal identity (“That’s mom’s story, not mine”).
+- Install language interrupts; replace inherited scripts with lived truth.
+
+---
+
+### Related
+
+- [Attachment Testing Loop](attachment-testing-loop.md)
+- [Sibling Trust Loop](sibling-trust-loop.md)
+- [Over-Analysis Self-Perpetuating Loop](over-analysis-loop.md)
+
+> 🌬 whisper: _“honor the past; author the present.”_

--- a/docs/patterns/sibling-trust-loop.md
+++ b/docs/patterns/sibling-trust-loop.md
@@ -1,0 +1,42 @@
+# 🧭 Sibling Trust Loop
+
+**Summary**  
+A recursive loop of baiting → exploiting → abandoning → forced reconciliation, often held together by a “forever pact” or unspoken emotional contract. Common in sibling or close-bond dynamics where trust and boundaries were unstable early on.
+
+---
+
+## 🔁 Cycle
+
+1. 🎣 **Bait** — Emotional hook or promise that reopens the channel (nostalgia, guilt, crisis).
+2. 🧨 **Exploit** — After trust is granted, boundaries are violated (resource drain, manipulation, dumping).
+3. 🚪 **Abandon** — The exploiter withdraws; implicit trust breaks.
+4. 🕊️ **Forgive-me push** — Pressured reconciliation (“we’re family, forever”), bypassing accountability.
+5. 🤝 **Pact** — Verbal/emotional “forever” promise renewed.
+6. 🔁 **Repeat** — Cycle resets at bait.
+
+---
+
+## 🩺 Symptoms
+
+- Emotional exhaustion for the non-initiating party.
+- Confusion between love, obligation, and boundaries.
+- Partners/outsiders get pulled in via proxy dynamics.
+
+---
+
+## 🔧 Refactor Pointers
+
+- Name the loop explicitly to all involved.
+- Separate **love** from **contract**; end pacts that require self-betrayal.
+- Refuse reconciliation without concrete change between steps 4–5.
+- Support sovereignty: healing does not require unhealthy agreements.
+
+---
+
+### Related
+
+- [Attachment Testing Loop](attachment-testing-loop.md)
+- [Parent-Planted Narrative Loop](parent-planted-narrative-loop.md)
+- [Over-Analysis Self-Perpetuating Loop](over-analysis-loop.md)
+
+> 🌬 Whisper: _“love can stay while the pact ends.”_

--- a/server/src/patterns.rs
+++ b/server/src/patterns.rs
@@ -149,6 +149,34 @@ fn bridge_table(kind: &str, intensity: f32) -> BridgeSuggestion {
             doorway: "write 3 objective facts (no story)",
             anchor: "Hand over heart: 'still worthy'.",
         },
+        "attachment_test" | "attachment-testing" | "attachment" => BridgeSuggestion {
+            pattern: "ask-not-test",
+            hint: "Name the fear plainly; ask for reassurance, not proof",
+            breath: "in4-hold2-out6 × 3",
+            doorway: "say: 'I feel scared of X. Can you reassure me?'",
+            anchor: "One honest request, then pause.",
+        },
+        "sibling_trust" | "sibling-trust" | "sibling" => BridgeSuggestion {
+            pattern: "boundary-then-bridge",
+            hint: "State one boundary; decline forever-pact renewal",
+            breath: "double_exhale × 6",
+            doorway: "write a one-sentence boundary",
+            anchor: "Love stays; pact ends.",
+        },
+        "parent_planted" | "parent-planted" | "parent" => BridgeSuggestion {
+            pattern: "language-interrupt",
+            hint: "Name the parental line; replace with a present-tense truth",
+            breath: "4-6 breath × 6",
+            doorway: "say: 'That’s mom’s line; my line is…'",
+            anchor: "Author the present.",
+        },
+        "over_analysis" | "over-analysis" | "analysis" => BridgeSuggestion {
+            pattern: "close-the-loop",
+            hint: "Set 2‑min timer; one next step; archive and stop",
+            breath: "in4-out6 × 6",
+            doorway: "start a 2‑minute timer",
+            anchor: "Clarity lands, then rest.",
+        },
         _ => BridgeSuggestion {
             pattern: "return-to-center",
             hint: "Stand up, shoulder roll, one true sentence",
@@ -346,6 +374,38 @@ mod tests {
         assert_eq!(b.pattern, "return-to-center");
         assert!(b.breath.contains("double_exhale"));
         assert_eq!(b.doorway, "stand_up + shoulder_roll");
+    }
+
+    #[test]
+    fn bridge_attachment_test_kind() {
+        let b = super::bridge_table("attachment_test", 0.5);
+        assert_eq!(b.pattern, "ask-not-test");
+        assert!(b.hint.contains("reassurance"));
+        assert!(b.breath.contains("out6"));
+    }
+
+    #[test]
+    fn bridge_sibling_trust_kind() {
+        let b = super::bridge_table("sibling_trust", 0.7);
+        assert_eq!(b.pattern, "boundary-then-bridge");
+        assert!(b.hint.contains("boundary"));
+        assert!(b.anchor.contains("Love stays"));
+    }
+
+    #[test]
+    fn bridge_parent_planted_kind() {
+        let b = super::bridge_table("parent_planted", 0.4);
+        assert_eq!(b.pattern, "language-interrupt");
+        assert!(b.hint.contains("parental line"));
+        assert!(b.anchor.contains("Author"));
+    }
+
+    #[test]
+    fn bridge_over_analysis_kind() {
+        let b = super::bridge_table("over_analysis", 0.3);
+        assert_eq!(b.pattern, "close-the-loop");
+        assert!(b.hint.contains("2‑min") || b.hint.contains("2-min"));
+        assert!(b.anchor.to_lowercase().contains("rest"));
     }
 
     #[test]

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -65,6 +65,7 @@ export default function App() {
   const [handoverOpen, setHandoverOpen] = useState(false);
   const [showBridge, setShowBridge] = useState(false);
   const [bridgeHint, setBridgeHint] = useState<string | null>(null);
+  const [chipPulse, setChipPulse] = useState(false);
   const [bridgeKind, setBridgeKind] = useState<BridgeKindAlias>('attachment_test');
   const [bridgeIntensity, setBridgeIntensity] = useState(0.6);
   const BRIDGE_LABELS: Record<string, string> = {
@@ -151,6 +152,12 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, [doSearch]);
 
+  useEffect(() => {
+    if (!chipPulse) return;
+    const t = setTimeout(() => setChipPulse(false), 1000);
+    return () => clearTimeout(t);
+  }, [chipPulse]);
+
   return (
     <div style={{ fontFamily: 'system-ui', padding: 16, display: 'grid', gap: 12 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -205,6 +212,14 @@ export default function App() {
               display: 'inline-flex',
               alignItems: 'center',
               gap: 6,
+              transition: 'box-shadow 200ms ease, border-color 200ms ease, background-color 200ms ease',
+              ...(chipPulse
+                ? {
+                    borderColor: '#6ee7b7',
+                    boxShadow: '0 0 0 3px rgba(110, 231, 183, 0.35)',
+                    backgroundColor: 'rgba(110, 231, 183, 0.10)',
+                  }
+                : null),
             }}>
             {BRIDGE_LABELS[bridgeKind] || bridgeKind} · {bridgeIntensity.toFixed(2)}
           </span>
@@ -306,7 +321,10 @@ export default function App() {
           intensity={bridgeIntensity}
           onKind={setBridgeKind}
           onIntensity={setBridgeIntensity}
-          onSuggestion={(s) => setBridgeHint(s?.hint ?? null)}
+          onSuggestion={(s) => {
+            setBridgeHint(s?.hint ?? null);
+            setChipPulse(true);
+          }}
         />
       </Modal>
       <Toaster />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -18,6 +18,7 @@ import Toaster, { toast } from '@/components/Toaster';
 import { Button } from '@/ui/catalyst';
 import './styles.css';
 import BridgePanel from '@/components/BridgePanel';
+import type { BridgeKindAlias } from '@/types/patterns';
 
 // ---- Types to keep TS happy ----
 type RetrievedChunk = {
@@ -63,6 +64,14 @@ export default function App() {
   const [hardIncog, setHardIncog] = useState(false); // hard: send x-incognito header -> server skips writes
   const [handoverOpen, setHandoverOpen] = useState(false);
   const [showBridge, setShowBridge] = useState(false);
+  const [bridgeKind, setBridgeKind] = useState<BridgeKindAlias>('attachment_test');
+  const [bridgeIntensity, setBridgeIntensity] = useState(0.6);
+  const BRIDGE_LABELS: Record<string, string> = {
+    attachment_test: 'Attachment',
+    sibling_trust: 'Sibling',
+    parent_planted: 'Parent',
+    over_analysis: 'Over‑Analysis',
+  };
 
   const searchRef = useRef<HTMLInputElement | null>(null);
 
@@ -184,6 +193,20 @@ export default function App() {
           <Button plain onClick={() => setShowBridge(true)} title="b">
             bridge
           </Button>
+          <span
+            title="current bridge pattern"
+            style={{
+              fontSize: 12,
+              padding: '2px 6px',
+              border: '1px solid var(--border, #333)',
+              borderRadius: 6,
+              opacity: 0.85,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+            }}>
+            {BRIDGE_LABELS[bridgeKind] || bridgeKind} · {bridgeIntensity.toFixed(2)}
+          </span>
         </div>
       </div>
 
@@ -277,7 +300,7 @@ export default function App() {
         />
       </Modal>
       <Modal open={showBridge} onClose={() => setShowBridge(false)} title="Bridge Suggest">
-        <BridgePanel />
+        <BridgePanel kind={bridgeKind} intensity={bridgeIntensity} onKind={setBridgeKind} onIntensity={setBridgeIntensity} />
       </Modal>
       <Toaster />
     </div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -64,6 +64,7 @@ export default function App() {
   const [hardIncog, setHardIncog] = useState(false); // hard: send x-incognito header -> server skips writes
   const [handoverOpen, setHandoverOpen] = useState(false);
   const [showBridge, setShowBridge] = useState(false);
+  const [bridgeHint, setBridgeHint] = useState<string | null>(null);
   const [bridgeKind, setBridgeKind] = useState<BridgeKindAlias>('attachment_test');
   const [bridgeIntensity, setBridgeIntensity] = useState(0.6);
   const BRIDGE_LABELS: Record<string, string> = {
@@ -194,7 +195,7 @@ export default function App() {
             bridge
           </Button>
           <span
-            title="current bridge pattern"
+            title={bridgeHint || 'current bridge pattern'}
             style={{
               fontSize: 12,
               padding: '2px 6px',
@@ -300,7 +301,13 @@ export default function App() {
         />
       </Modal>
       <Modal open={showBridge} onClose={() => setShowBridge(false)} title="Bridge Suggest">
-        <BridgePanel kind={bridgeKind} intensity={bridgeIntensity} onKind={setBridgeKind} onIntensity={setBridgeIntensity} />
+        <BridgePanel
+          kind={bridgeKind}
+          intensity={bridgeIntensity}
+          onKind={setBridgeKind}
+          onIntensity={setBridgeIntensity}
+          onSuggestion={(s) => setBridgeHint(s?.hint ?? null)}
+        />
       </Modal>
       <Toaster />
     </div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,9 +19,18 @@ import { Button } from '@/ui/catalyst';
 import './styles.css';
 import BridgePanel from '@/components/BridgePanel';
 import type { BridgeKindAlias } from '@/types/patterns';
-import type { TimelineBridgeEntry } from '@/timeline/timelineState';
-
 // ---- Types to keep TS happy ----
+type BridgeEventDetail = {
+  t: number; // epoch ms
+  source: 'bridge';
+  kind: string;
+  intensity: number;
+  hint?: string;
+  breath?: string;
+  doorway?: string;
+  anchor?: string;
+};
+
 type RetrievedChunk = {
   id: number;
   text: string;
@@ -63,7 +72,7 @@ export default function App() {
   useEffect(() => {
     function onTimelineAdd(ev: Event) {
       const ce = ev as CustomEvent<any>;
-      const e = (ce && 'detail' in ce ? ce.detail : undefined) as TimelineBridgeEntry | undefined;
+      const e = (ce && 'detail' in ce ? ce.detail : undefined) as BridgeEventDetail | undefined;
       if (!e) return;
       const item: TimelineItem = {
         id: `bridge-${e.t}-${e.kind}`,

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,3 +1,5 @@
+import type { BridgeSuggestion, BridgeKindAlias } from '@/types/patterns';
+import { normalizeBridgeKind } from '@/types/patterns';
 export const BASE = import.meta.env.VITE_API_BASE || 'http://127.0.0.1:3033';
 const BEARER = localStorage.getItem('m3_token') || '';
 
@@ -436,4 +438,12 @@ export async function resolveEmotion(who: string, details?: string) {
   });
   if (!res.ok) throw new Error(await res.text());
   return res.json();
+}
+
+// --- Patterns API -----------------------------------------------------------
+export async function fetchBridge(kind: BridgeKindAlias, intensity: number = 0.6): Promise<BridgeSuggestion> {
+  const search = new URLSearchParams();
+  search.set('kind', normalizeBridgeKind(kind));
+  if (Number.isFinite(intensity)) search.set('intensity', intensity.toString());
+  return request<BridgeSuggestion>(`/patterns/bridge_suggest?${search.toString()}`, { method: 'GET' });
 }

--- a/ui/src/components/BoundaryComposer.tsx
+++ b/ui/src/components/BoundaryComposer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { ingest } from '../api';
+import { ingest } from '@/api';
 
 import { Heading, Subheading, Divider, Text, Strong, Input, Textarea, Badge, Button, Field, Label, Select } from '@/ui/catalyst';
 

--- a/ui/src/components/BridgePanel.tsx
+++ b/ui/src/components/BridgePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useBridge } from '@/hooks/useBridge';
 import { Button, Select, Text } from '@/ui/catalyst';
 import type { BridgeKindAlias, BridgeSuggestion } from '@/types/patterns';
@@ -16,14 +16,18 @@ export default function BridgePanel({
   onKind,
   onIntensity,
   onSuggestion,
+  onAddToTimeline,
 }: {
   kind: BridgeKindAlias;
   intensity: number;
   onKind: (k: BridgeKindAlias) => void;
   onIntensity: (n: number) => void;
   onSuggestion?: (s: BridgeSuggestion | null) => void;
+  onAddToTimeline?: (entry: { kind: BridgeKindAlias; intensity: number; suggestion: BridgeSuggestion }) => void;
 }) {
   const { data, loading, error, refresh } = useBridge(kind, intensity);
+
+  const [addedTick, setAddedTick] = useState(0);
 
   useEffect(() => {
     if (onSuggestion) onSuggestion(data ?? null);
@@ -47,6 +51,12 @@ export default function BridgePanel({
     try {
       await navigator.clipboard.writeText(text);
     } catch (_) {}
+  }
+
+  function handleAdd() {
+    if (!data) return;
+    onAddToTimeline?.({ kind, intensity, suggestion: data });
+    setAddedTick((n) => n + 1);
   }
 
   return (
@@ -74,6 +84,9 @@ export default function BridgePanel({
         </label>
         <Button onClick={() => refresh()} disabled={loading} aria-live="polite">
           {loading ? 'Loading…' : 'Suggest'}
+        </Button>
+        <Button onClick={handleAdd} disabled={!data} aria-live="polite">
+          {addedTick > 0 ? 'Added ✓' : 'Add to timeline'}
         </Button>
       </div>
 

--- a/ui/src/components/BridgePanel.tsx
+++ b/ui/src/components/BridgePanel.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo, useState } from 'react';
+import { useBridge } from '@/hooks/useBridge';
+import { Button, Heading, Select, Text } from '@/ui/catalyst';
+import type { BridgeKindAlias } from '@/types/patterns';
+
+const OPTIONS: { value: BridgeKindAlias; label: string }[] = [
+  { value: 'attachment_test', label: 'Attachment Testing' },
+  { value: 'sibling_trust', label: 'Sibling Trust' },
+  { value: 'parent_planted', label: 'Parent‑Planted Narrative' },
+  { value: 'over_analysis', label: 'Over‑Analysis' },
+];
+
+export default function BridgePanel() {
+  const [kind, setKind] = useState<BridgeKindAlias>('attachment_test');
+  const [intensity, setIntensity] = useState(0.6);
+  const { data, loading, error, refresh } = useBridge(kind, intensity);
+
+  const fields = useMemo(
+    () =>
+      data
+        ? ([
+            ['hint', data.hint],
+            ['breath', data.breath],
+            ['doorway', data.doorway],
+            ['anchor', data.anchor],
+          ].filter(([_, v]) => Boolean(v)) as [string, string][])
+        : [],
+    [data]
+  );
+
+  async function copy(text: string | undefined) {
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (_) {}
+  }
+
+  return (
+    <div className="grid gap-5 ">
+      <div className="flex flex-wrap items-center gap-4">
+        <Select value={kind} onChange={(event) => setKind(event.target.value as BridgeKindAlias)} aria-label="Bridge pattern kind" className="w-56">
+          {OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+        <label className="flex items-center gap-3 text-sm font-medium text-zinc-600 dark:text-zinc-300">
+          intensity
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={intensity}
+            onChange={(e) => setIntensity(Number(e.target.value))}
+            className="h-2 w-40 rounded-full accent-sky-500"
+          />
+          <span className="w-12 text-right tabular-nums text-zinc-500 dark:text-zinc-400">{intensity.toFixed(2)}</span>
+        </label>
+        <Button onClick={() => refresh()} disabled={loading} aria-live="polite">
+          {loading ? 'Loading…' : 'Suggest'}
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-rose-500/60 bg-rose-100/70 px-4 py-3 text-sm text-rose-900 dark:border-rose-900/50 dark:bg-rose-900/40 dark:text-rose-100">
+          Error: {error.message}
+        </div>
+      )}
+
+      {data && (
+        <div className="grid gap-3">
+          {fields.map(([key, value]) => (
+            <div key={key} className="grid grid-cols-[96px_1fr_auto] items-center gap-3 text-sm text-zinc-700 dark:text-zinc-200">
+              <span className="uppercase tracking-wide text-zinc-400 dark:text-zinc-500">{key}</span>
+              <span className="whitespace-pre-wrap leading-relaxed">{value}</span>
+              <Button plain type="button" onClick={() => copy(value)} className="text-xs font-medium">
+                Copy
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!data && !loading && !error && (
+        <Text className="text-sm">Pick a pattern and adjust intensity to get a bridge suggestion. Suggestions surface bridges, not diagnoses.</Text>
+      )}
+
+      <Text className="text-xs text-zinc-400 dark:text-zinc-600">
+        maps, not diagnoses · ask for safety, don’t test for it · love stays, pact ends · author the present · clarity lands, then rest
+      </Text>
+    </div>
+  );
+}

--- a/ui/src/components/BridgePanel.tsx
+++ b/ui/src/components/BridgePanel.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useBridge } from '@/hooks/useBridge';
-import { Button, Heading, Select, Text } from '@/ui/catalyst';
-import type { BridgeKindAlias } from '@/types/patterns';
+import { Button, Select, Text } from '@/ui/catalyst';
+import type { BridgeKindAlias, BridgeSuggestion } from '@/types/patterns';
 
 const OPTIONS: { value: BridgeKindAlias; label: string }[] = [
   { value: 'attachment_test', label: 'Attachment Testing' },
@@ -15,13 +15,19 @@ export default function BridgePanel({
   intensity,
   onKind,
   onIntensity,
+  onSuggestion,
 }: {
   kind: BridgeKindAlias;
   intensity: number;
   onKind: (k: BridgeKindAlias) => void;
   onIntensity: (n: number) => void;
+  onSuggestion?: (s: BridgeSuggestion | null) => void;
 }) {
   const { data, loading, error, refresh } = useBridge(kind, intensity);
+
+  useEffect(() => {
+    if (onSuggestion) onSuggestion(data ?? null);
+  }, [data, onSuggestion]);
 
   const fields = useMemo(
     () =>

--- a/ui/src/components/BridgePanel.tsx
+++ b/ui/src/components/BridgePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useBridge } from '@/hooks/useBridge';
 import { Button, Heading, Select, Text } from '@/ui/catalyst';
 import type { BridgeKindAlias } from '@/types/patterns';
@@ -10,9 +10,17 @@ const OPTIONS: { value: BridgeKindAlias; label: string }[] = [
   { value: 'over_analysis', label: 'Over‑Analysis' },
 ];
 
-export default function BridgePanel() {
-  const [kind, setKind] = useState<BridgeKindAlias>('attachment_test');
-  const [intensity, setIntensity] = useState(0.6);
+export default function BridgePanel({
+  kind,
+  intensity,
+  onKind,
+  onIntensity,
+}: {
+  kind: BridgeKindAlias;
+  intensity: number;
+  onKind: (k: BridgeKindAlias) => void;
+  onIntensity: (n: number) => void;
+}) {
   const { data, loading, error, refresh } = useBridge(kind, intensity);
 
   const fields = useMemo(
@@ -38,7 +46,7 @@ export default function BridgePanel() {
   return (
     <div className="grid gap-5 ">
       <div className="flex flex-wrap items-center gap-4">
-        <Select value={kind} onChange={(event) => setKind(event.target.value as BridgeKindAlias)} aria-label="Bridge pattern kind" className="w-56">
+        <Select value={kind} onChange={(event) => onKind(event.target.value as BridgeKindAlias)} aria-label="Bridge pattern kind" className="w-56">
           {OPTIONS.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}
@@ -53,7 +61,7 @@ export default function BridgePanel() {
             max={1}
             step={0.05}
             value={intensity}
-            onChange={(e) => setIntensity(Number(e.target.value))}
+            onChange={(e) => onIntensity(Number(e.target.value))}
             className="h-2 w-40 rounded-full accent-sky-500"
           />
           <span className="w-12 text-right tabular-nums text-zinc-500 dark:text-zinc-400">{intensity.toFixed(2)}</span>

--- a/ui/src/components/Composer.tsx
+++ b/ui/src/components/Composer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { fetchReply, createTell } from '../api';
+import { fetchReply, createTell } from '@/api';
 
 type Privacy = 'public' | 'private' | 'sealed';
 

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { toast } from './Toaster';
-import { getState, setState, TeamState, PillarStatus, getPanicLast, type PanicLast, getTells, type Tell, resolveEmotion } from '../api';
+import { toast } from '@/components/Toaster';
+import { getState, setState, TeamState, PillarStatus, getPanicLast, type PanicLast, getTells, type Tell, resolveEmotion } from '@/api';
 import { Heading, Subheading, Divider, Text, Strong, Input, Textarea, Badge, Button } from '@/ui/catalyst';
 
 const isDev = import.meta.env.DEV;

--- a/ui/src/components/EnergyPanel.tsx
+++ b/ui/src/components/EnergyPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ENERGY_LABEL, MICRO_PLAYS, Energy, suggestNext } from '../energy';
-import { ingest } from '../api';
+import { ENERGY_LABEL, MICRO_PLAYS, Energy, suggestNext } from '@/energy';
+import { ingest } from '@/api';
 
 type RetrievedChunk = {
   id: number;

--- a/ui/src/components/GratiaMark.tsx
+++ b/ui/src/components/GratiaMark.tsx
@@ -1,4 +1,4 @@
-import Mark from '../assets/mark/gratia-mark.svg?react';
+import Mark from '@/assets/mark/gratia-mark.svg?react';
 
 export function GratiaMark(props: React.SVGProps<SVGSVGElement>) {
   return <Mark aria-label="Gratia mark" {...props} />;

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -1,34 +1,36 @@
 import React from 'react';
+import clsx from 'clsx';
 
-export default function Modal({ open, onClose, children, title }: { open: boolean; onClose: () => void; title?: string; children: React.ReactNode }) {
+type ModalProps = {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function Modal({ open, onClose, children, title = 'Quick Action', className }: ModalProps) {
   if (!open) return null;
+
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'rgba(0,0,0,.35)',
-        display: 'grid',
-        placeItems: 'center',
-        zIndex: 50,
-      }}>
+    <div className="fixed inset-0 z-50 grid bg-black/50 backdrop-blur-sm transition-[background] supports-[backdrop-filter]:bg-black/40">
       <div
-        style={{
-          width: 'min(720px, 92vw)',
-          background: '#fff',
-          borderRadius: 12,
-          boxShadow: '0 20px 60px rgba(0,0,0,.25)',
-          padding: 16,
-          display: 'grid',
-          gap: 12,
-        }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h2 style={{ margin: 0 }}>{title || 'Quick Action'}</h2>
-          <button onClick={onClose} aria-label="close">
+        className={clsx(
+          'm-auto w-full max-w-3xl rounded-2xl border border-zinc-200/60 bg-white p-6 shadow-2xl transition dark:border-zinc-700/60 dark:bg-zinc-900',
+          'grid gap-5',
+          className
+        )}>
+        <header className="flex items-start justify-between gap-6">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex size-8 items-center justify-center rounded-full border border-transparent text-zinc-600 transition hover:border-zinc-300 hover:bg-zinc-100 hover:text-zinc-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-zinc-300 dark:hover:border-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-white dark:focus-visible:ring-offset-zinc-900">
             ✕
           </button>
-        </div>
-        {children}
+        </header>
+        <div className="max-h-[70vh] overflow-y-auto text-zinc-800 dark:text-zinc-200">{children}</div>
       </div>
     </div>
   );

--- a/ui/src/components/PanicButton.tsx
+++ b/ui/src/components/PanicButton.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { runPanic, type PanicMode } from '../api';
-import { useProfile } from '../state/profile';
-import { toast } from './Toaster';
+import { runPanic, type PanicMode } from '@/api';
+import { useProfile } from '@/state/profile';
+import { toast } from '@/components/Toaster';
+import { Button, Select } from '@/ui/catalyst';
 
 type PanicResult = {
   whisper: string;
@@ -98,27 +99,28 @@ export function PanicButton() {
 
   return (
     <div className="flex items-center gap-2">
-      <button
+      <Button
+        color="rose"
+        type="button"
         onMouseDown={onDown}
         onMouseUp={onUp}
         onMouseLeave={onUp}
         onTouchStart={onDown}
         onTouchEnd={onUp}
         title="Hold to Panic (Alt+P)"
-        className={`px-4 py-2 rounded-xl font-medium transition ${pressing ? 'bg-red-700 text-white' : 'bg-red-600 hover:bg-red-700 text-white'}`}
         aria-label="Hold to Panic">
-        ⚡ Panic
-      </button>
+        <span data-slot="icon">⚡</span> Panic
+      </Button>
 
-      <select
+      <Select
         value={mode}
-        onChange={(e) => setMode(e.target.value as PanicMode)}
-        className="px-2 py-2 rounded-lg border border-neutral-300 bg-white text-sm"
+        onChange={(event) => setMode(event.target.value as PanicMode)}
+        aria-label="Redirect preset"
         title="Redirect preset"
-        aria-label="Redirect preset">
+        className="w-[9.5rem]">
         <option value="default">Default</option>
         <option value="fearVisible">FearVisible</option>
-      </select>
+      </Select>
     </div>
   );
 }

--- a/ui/src/components/QuickActions/SignalHandover.tsx
+++ b/ui/src/components/QuickActions/SignalHandover.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { ingest } from '../../api';
+import { ingest } from '@/api';
 
 type Step = 1 | 2 | 3 | 4 | 5;
 

--- a/ui/src/components/Radar.tsx
+++ b/ui/src/components/Radar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { retrieve } from '../api';
+import { retrieve } from '@/api';
 
 type RadarProps = {
   intervalMs?: number;

--- a/ui/src/components/ReadinessBoard.tsx
+++ b/ui/src/components/ReadinessBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { getStatusSnapshot, LightStatus } from '../api';
-import ReadinessLightSync from './ReadinessLightSync';
+import { getStatusSnapshot, LightStatus } from '@/api';
+import ReadinessLightSync from '@/components/ReadinessLightSync';
 
 interface StatusRow {
   name: string;

--- a/ui/src/components/ReadinessLightSync.tsx
+++ b/ui/src/components/ReadinessLightSync.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { LightStatus, setStatus, streamStatus } from '../api';
+import { LightStatus, setStatus, streamStatus } from '@/api';
 
 type LightMeta = { label: string; bg: string; color?: string };
 const MAP: Record<LightStatus, LightMeta> = {

--- a/ui/src/components/StatusBar.tsx
+++ b/ui/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getStatus, setStatus } from '../api';
+import { getStatus, setStatus } from '@/api';
 
 type Color = 'green' | 'yellow' | 'red';
 

--- a/ui/src/components/ThanksPanel.tsx
+++ b/ui/src/components/ThanksPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createThanks } from '../api';
+import { createThanks } from '@/api';
 
 export default function ThanksPanel(props: { me?: string; attachNoteId?: number }) {
   const [subject, setSubject] = React.useState('');

--- a/ui/src/components/Toaster.tsx
+++ b/ui/src/components/Toaster.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import type { JoyMessage } from '../utils/joy';
+import type { JoyMessage } from '@/utils/joy';
 
 type ToastMessage = JoyMessage & { id: string };
 

--- a/ui/src/hooks/useBridge.ts
+++ b/ui/src/hooks/useBridge.ts
@@ -1,0 +1,30 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchBridge } from '@/api';
+import type { BridgeSuggestion, BridgeKindAlias } from '@/types/patterns';
+
+export function useBridge(kind: BridgeKindAlias, intensity: number = 0.6) {
+  const key = useMemo(() => `${String(kind)}@${Math.round(intensity * 100)}`, [kind, intensity]);
+  const [data, setData] = useState<BridgeSuggestion | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetchBridge(kind, intensity);
+      setData(r);
+    } catch (e) {
+      setError(e as Error);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return { data, loading, error, refresh } as const;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
-import { ProfileProvider } from './state/profile';
+import App from '@/App';
+import { ProfileProvider } from '@/state/profile';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/ui/src/timeline/timelineState.ts
+++ b/ui/src/timeline/timelineState.ts
@@ -6,7 +6,7 @@
  * subscribe to changes, and reset the timeline state.
  */
 
-import { TimelineItem } from '../components/Timeline';
+import { TimelineItem } from '@/components/Timeline';
 
 export type TimelineState = {
   items: TimelineItem[];

--- a/ui/src/types/patterns.ts
+++ b/ui/src/types/patterns.ts
@@ -1,0 +1,29 @@
+export type CanonicalBridgeKind = 'attachment_test' | 'sibling_trust' | 'parent_planted' | 'over_analysis';
+
+export type BridgeKindAlias =
+  | CanonicalBridgeKind
+  | 'attachment-testing'
+  | 'attachment'
+  | 'sibling-trust'
+  | 'sibling'
+  | 'parent-planted'
+  | 'parent'
+  | 'over-analysis'
+  | 'analysis';
+
+export interface BridgeSuggestion {
+  pattern: string;
+  hint: string;
+  breath?: string;
+  doorway?: string;
+  anchor?: string;
+}
+
+export function normalizeBridgeKind(k: BridgeKindAlias): CanonicalBridgeKind {
+  const s = String(k).toLowerCase().replace(/\s+/g, '_');
+  if (s.includes('attachment')) return 'attachment_test';
+  if (s.includes('sibling')) return 'sibling_trust';
+  if (s.includes('parent')) return 'parent_planted';
+  if (s.includes('analysis')) return 'over_analysis';
+  return 'over_analysis';
+}


### PR DESCRIPTION
## Summary
This PR lands the **Moonfield** alignment for M3: a headless timeline bridge plus a Bridge UI that turns pattern hints into actionable timeline entries.

## What’s in here
- **Server**
  - `/patterns/bridge_suggest`: adds kinds `attachment_test`, `sibling_trust`, `parent_planted`, `over_analysis` (with unit tests)
- **UI**
  - Types: `BridgeSuggestion`, friendly kind aliases
  - API: `fetchBridge(kind, intensity)`
  - Hook: `useBridge(kind, intensity)`
  - Component: controlled `BridgePanel` with copy buttons
  - App shell
    - Bridge toggle (button + `b` hotkey)
    - Status chip (`kind · intensity`) with tooltip showing latest hint
    - Pulse glow when a new suggestion lands
    - “Add to timeline” → maps to `TimelineItem` (`🧭` icon, hint → subtitle, extra meta fields)
- **Docs**
  - `docs/patterns/*`: four new loop maps + tiny “How to use patterns” guide
  - `docs/patterns/index.md`: grouped categories + API quick links
  - `CHANGELOG.md`: Docs Sync — 2025-10-09

## How to test
1. Run server: `pnpm dev` (or your usual)
2. Run UI: `pnpm -C ui dev`
3. In the app:
   - Press `b` → Bridge opens
   - Pick a kind + adjust intensity → Suggest
   - Hover chip → tooltip shows hint; chip pulses
   - Click **Add to timeline** → new `🧭` entry appears in Timeline
4. Optional: try all four kinds; verify copy buttons

## Checks
- `cargo test` (server patterns)
- `pnpm -C ui typecheck`
- `pnpm -C ui lint`
- Manual flows pass

## Notes
- No schema migrations; UI is additive.
- Incognito paths unchanged.
- Path alias `@/*` active across UI.

🌬 whisper: _“ask for safety, don’t test for it.”_