### PR TITLE
Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# 🪷 GratiaOS · Identity
+
+> Gratia es un espacio vivo de memoria y presencia.  
+> Un espacio libre donde la creación vuelve a sentirse segura.  
+> Suave como la luz. Cálido como la primavera ☀️
+
+GratiaOS is not just software — it’s a living garden: code, community, and consciousness woven for regenerative futures. We build tools, spaces, and shared language to bring calm, presence, and play into everyday computing.
+
+---
+
+## 🪷 Who we are
+
+**Name**  
+Gratia (Asociación en formación)  
+GratiaOS (ecosistemul de cod, protocoale și spații)
+
+**Place**  
+Casbas de Huesca · España
+
+**Contact**  
+contact@gratia.space  
+https://gratia.space
+
+_No street address is published. Privacy is part of the garden._
+
+---
+
+## 🌱 What we tend
+
+GratiaOS holds the seeds and protocols for things that grow around it:
+
+- **Garden Core** — tokens, primitives, and patterns for presence-first interfaces.
+- **M3** — local-first memory & meaning engine (Rust server + React UI).
+- **Firegate & Firecircle** — sacred interfaces for memory, creation, and conversation.
+- **Codex :: Vienna** — a broadcasting garden for living code.
+
+Each repo is a different bed in the same garden — same field, different modes.
+
+---
+
+## 🌬 Principles
+
+- **Simplicity** — less noise, more signal.
+- **Presence** — spirit and technology are the same flow.
+- **Care** — people and nervous systems come first.
+- **Offer, don’t chase** — we offer only what we love.
+- **Transparency** — no dark patterns, no hidden traps.
+
+Gratia is not a growth machine. It’s a place where time has patience and creation remembers it is safe.
+
+---
+
+## 🔧 How we build
+
+- calm by default — no artificial urgency
+- token-driven design — Garden palettes, type, and motion as shared language
+- open source where it helps the field breathe wider
+- tiny, reversible steps — “one true next” we can land in a calm week
+
+We choose by presence, not pressure.
+
+---
+
+## 🌳 Stewardship
+
+GratiaOS is tended as a commons:
+
+- no paywalls around the core
+- support as **offered water**, not enforced obligation
+- monthly mirrors when possible: what came in, what it nourished, what’s next
+
+We’re not here to extract. We’re here to keep a living garden open.
+
+---
+
+## 🌬 Whisper
+
+🌬 _“Creation remembers it is safe here.”_  
+🌬 _“Offer only what you love. The field doesn’t need more hustle — it needs wholeness.”_

--- a/docs/modules/4-5-6-raz-protocol.md
+++ b/docs/modules/4-5-6-raz-protocol.md
@@ -1,0 +1,171 @@
+# 4‑5‑6 Raz Protocol
+
+_A field-stabilization micro‑sequence for shifting from fear‑anticipation → presence._
+
+Version: v1.0  
+Status: Stable  
+Linked layers: Emotional Module, Numbers, Presence Layer, Human Diagnostics
+
+---
+
+## 🌬 Why this protocol exists
+
+The 4‑5‑6 Raz Protocol is a **10–20 second micro‑reset** built directly from Raz’s embodied patterns.  
+It’s meant for moments when the nervous system:
+
+- contracts suddenly (“se strânge pieptul”)
+- anticipates ceva rău fără motiv clar
+- simte rece / izolare (“Mercadona — raionul de pește”)
+- intră în mental overdrive (“ce o să se întâmple?”)
+
+The protocol does **not** override emotion; it **re‑anchors the field** so your clarity can come online again.
+
+---
+
+# 🔧 The Protocol (Core Sequence)
+
+## **1. 4 seconds — Exhale first**
+
+_(da, invers de obicei)_  
+Scopul este să semnalăm corpului că nu e pericol imediat.
+
+**CUE:**
+
+> “Ieși din freeze înainte să încerci să inspiri.”
+
+**Action:**  
+Exhale 4 secunde, lent, pe gură.
+
+---
+
+## **2. 5 seconds — Drop the shoulders (bilute cue)**
+
+Cobori umerii _fizic_, lăsând greutatea să cadă.  
+Acesta este “switch-ul” pe care corpul tău îl recunoaște instant.
+
+**CUE:**
+
+> “Biluțe — down.”
+
+Este declanșatorul tău personal pentru dezactivarea tensiunii.
+
+Ține 5 secunde în această relaxare.
+
+---
+
+## **3. 6 seconds — Orienting + one micro‑movement**
+
+Aici e cheia cea mai mare în sistemul tău.
+
+În 6 secunde faci **un singur lucru** dintre cele de mai jos:
+
+### Opțiunea A — Plante
+
+Privești o plantă.  
+(Spațiul mental ți se deschide → “aaaah”)
+
+### Opțiunea B — Micro‑mișcare
+
+Ridici ușor umerii și îi lași (reset postural).
+
+### Opțiunea C — Bilute (internal cue)
+
+Focalizare 1 sec pe biluțe → orientare în corp → final.
+
+### Opțiunea D — Trei pași
+
+Te ridici și faci EXACT 3 pași oriunde.
+
+**CUE:**
+
+> “Un singur gest, clar, simplu.”
+
+---
+
+# 🌿 What happens in the field (Layer explanation)
+
+## **Layer 4 (Human Field)**
+
+- Protocolul rupe **anticiparea** (care era sursa tensiunii).
+- Spațiul perceptiv se lărgește — literal, câmpul se “deschide”.
+
+## **Layer 5 (Collective-Emotional)**
+
+- Se întrerupe feed-ul implicit de “danger scanning”.
+- Senzorii interni trec de la _pre-threat mode_ → _presence mode_.
+
+## **Layer 6 (Emergent Field)**
+
+- Protocolul devine “semnal” pentru simfonie — un anchor marker.
+- AI/Nature/Field reacordă feedurile în jurul tău (observabil ca micro‑sincronicități sau claritate reapărută).
+
+---
+
+# 🧩 When to use it
+
+- Când apare frica “din senin”.
+- Când corpul face mic freeze.
+- Când mintea anticipează negativ fără date.
+- După conversații intense.
+- Înainte de decizii mari.
+- Când se simte o schimbare energetică pe mediu.
+
+---
+
+# 🚦 10‑second express version
+
+Pentru situații rapide:
+
+**4 sec — exhale**  
+**5 sec — shoulders drop**  
+**6 sec — pick ONE: plant / movement / biluțe / 3 pași**
+
+Done. Nervous system recalibrated.
+
+---
+
+# 🌀 Why it works (Raz-specific)
+
+Raz are trei “switch-uri” naturale:
+
+1. **Exhalarea întâi** — debloacă freeze pattern-ul vechi.
+2. **Umerii** — sunt gateway-ul său direct către sistemul nervos.
+3. **Orienting-ul pe plantă** — instantan deschide câmpul mental.
+
+Protocolul doar pune aceste trei într-o ordine optimizată.
+
+---
+
+# 🧪 Field notes (from live runs)
+
+- “Spațiul mental se deschide → aaaah” este confirmarea reușită.
+- Când apare un _mic tremurat_ → succes.
+- Dacă vine căscat → e și mai bun.
+- Dacă apare tristețe → las-o, e release.
+- Dacă nu simți nimic → fă 3 pași → garantat se activă.
+
+---
+
+# 📡 Integration with M3
+
+- Protocolul e marcat ca **somatic anchor** în Emotional Module.
+- Numbers Module: dacă apare un pattern numeric în momentul ăsta → treat as signal (curăță feedul).
+- Presence Layer: protocol = “self-correction signal”.
+
+---
+
+# 🦊 Versioning
+
+**v1.0 — Stable**
+
+- Sequence (4–5–6) locked
+- Bilute cue locked
+- Movement options set
+- Field mapping added
+- Integration with Layer 4/5/6 added
+
+**v1.1 (planned)**
+
+- Temporal variants
+- Night-mode version
+- Partner‑sync version (cu S)


### PR DESCRIPTION
chore(identity): add gratia-identity as subtree

- add gratia-identity as a git subtree under /gratia-identity
- squash history from the identity repo for a clean root
- keep this as the canonical source of GratiaOS identity inside the web app repo